### PR TITLE
Lowercase the hostname before comparing

### DIFF
--- a/text.js
+++ b/text.js
@@ -124,7 +124,7 @@ define(['module'], function (module) {
             uHostName = uHostName[0];
 
             return (!uProtocol || uProtocol === protocol) &&
-                   (!uHostName || uHostName === hostname) &&
+                   (!uHostName || uHostName.toLowerCase() === hostname.toLowerCase()) &&
                    ((!uPort && !uHostName) || uPort === port);
         },
 


### PR DESCRIPTION
For our application, we have a configuration file that specifies the URL to pull static content.  In some scenarios, it may exist in the config file with the same hostname as the primary URL but with a different case.  In those instances, the plugin was appending .js because it thought it had to go cross domain, when it reality the content was being served from the same host.  Lowercasing the hostname corrects that issue.
