### PR TITLE
Escape line terminators \u2028 and \u2029.

### DIFF
--- a/text.js
+++ b/text.js
@@ -47,7 +47,9 @@ define(['module'], function (module) {
                 .replace(/[\b]/g, "\\b")
                 .replace(/[\n]/g, "\\n")
                 .replace(/[\t]/g, "\\t")
-                .replace(/[\r]/g, "\\r");
+                .replace(/[\r]/g, "\\r")
+                .replace(/[\u2028]/g, "\\u2028")
+                .replace(/[\u2029]/g, "\\u2029");
         },
 
         createXhr: function () {


### PR DESCRIPTION
As per [the spec](http://es5.github.com/#x7.3), `"\u2028"` and `"\u2029"` must be escaped before inclusion in a string literal.
