### PR TITLE
!text modules can now be inlined without multiple whitespaces and linebreaks during optimization

### DIFF
--- a/text.js
+++ b/text.js
@@ -53,8 +53,7 @@ define(['module'], function (module) {
         },
 
         removeWhitespace: function (content) {
-            return content.replace(/ +(?= )/g,'')
-                .replace(/(\\r\\n|\\n|\\r)/gm,"");
+            return content.replace(/>\s+</g, "><");
         },
 
         createXhr: masterConfig.createXhr || function () {
@@ -189,11 +188,13 @@ define(['module'], function (module) {
 
         write: function (pluginName, moduleName, write, config) {
             if (buildMap.hasOwnProperty(moduleName)) {
-                var content = text.jsEscape(buildMap[moduleName]);
+                var content = buildMap[moduleName];
 
                 //Removes whitespace and line breaks
                 if (masterConfig.removeWhitespace)
                     content = text.removeWhitespace(content);
+
+                content = text.jsEscape(content);
 
                 write.asModule(pluginName + "!" + moduleName,
                                "define(function () { return '" +


### PR DESCRIPTION
We optimize our code with require.js and r.js and use !text to inline our HTML templates to our main.js. We needed to remove multiple whitespaces and linebreaks to optimize the size of our main file. It is solution used in Django framework. It serves us fine and everybody can turn it off anytime they want or do not use at all.

It would be great to restrict it only to .html suffix.

**_build.js**_

``` json
config: {
    text: {
        removeWhitespace: true
    }
}
```
