### PR TITLE
Change reference to export object to be "this" instead of local variable to allow overriding in other modules.

### DIFF
--- a/text.js
+++ b/text.js
@@ -155,7 +155,7 @@ define(['module'], function (module) {
 
             masterConfig.isBuild = config.isBuild;
 
-            var parsed = text.parseName(name),
+            var parsed = this.parseName(name),
                 nonStripName = parsed.moduleName + '.' + parsed.ext,
                 url = req.toUrl(nonStripName),
                 useXhr = (masterConfig.useXhr) ||


### PR DESCRIPTION
Example:

define(['text','underscore'], function(text, _) {
    'use strict';
    return _.extend({}, text, { parseName: function(name) {
        return text.parseName('../partials/' + name + '.html');
    }});
});

Before, the parseName function called would always be the original one.
