### PR TITLE
Add XHR error status code 0 for errback

### DIFF
--- a/text.js
+++ b/text.js
@@ -251,7 +251,7 @@ define(['module'], function (module) {
                 //visible via console output in the browser.
                 if (xhr.readyState === 4) {
                     status = xhr.status;
-                    if (status > 399 && status < 600) {
+                    if ((status > 399 && status < 600) || status == 0) {
                         //An http 4xx or 5xx error. Signal an error.
                         err = new Error(url + ' HTTP status: ' + status);
                         err.xhr = xhr;


### PR DESCRIPTION
This seems to occur for localhost file access errors in Chrome, which was causing the completion callback even when the file didn't exist.
