### PR TITLE
fixes #38 - gives access to xhr request headers via the .get api

### DIFF
--- a/text.js
+++ b/text.js
@@ -251,9 +251,18 @@ define(['module'], function (module) {
         };
     } else if (masterConfig.env === 'xhr' || (!masterConfig.env &&
             text.createXhr())) {
-        text.get = function (url, callback, errback) {
-            var xhr = text.createXhr();
+        text.get = function (url, callback, errback, headers) {
+            var xhr = text.createXhr(), header;
             xhr.open('GET', url, true);
+
+            //Allow plugins direct access to xhr headers
+            if (headers) {
+                for (header in headers) {
+                    if (headers.hasOwnProperty(header)) {
+                        xhr.setRequestHeader(header.toLowerCase(), headers[header]);
+                    }
+                }
+            }
 
             //Allow overrides specified in config
             if (masterConfig.onXhr) {


### PR DESCRIPTION
Allows you to pass an object argument to the `text.get` which then gets set on the xhr instance. Useful for plugins like `json` that use the `text` plugin but do not set a `content-type` and thus break certain restful implementations. 
