### PR TITLE
Not assuming extension when requiring cross domain

### DIFF
--- a/text.js
+++ b/text.js
@@ -191,7 +191,7 @@ define(['module'], function (module) {
                 //by the module name + extension, but do not include the
                 //!strip part to avoid file system issues.
                 req([nonStripName], function (content) {
-                    text.finishLoad(parsed.moduleName + '.' + parsed.ext,
+                    text.finishLoad(parsed.moduleName,
                                     parsed.strip, content, onLoad);
                 });
             }


### PR DESCRIPTION
It would be quite useful for me to be able to require a text file with arbitrary extension from a different domain. Also other people find this useful and their answer to this question http://stackoverflow.com/questions/10607370/require-js-text-plugin-adds-js-to-the-file-name lead me here
