### PR TITLE
Change buildMap to object literal from array literal

### DIFF
--- a/text.js
+++ b/text.js
@@ -19,7 +19,7 @@ define(['module'], function (module) {
         defaultProtocol = hasLocation && location.protocol && location.protocol.replace(/\:/, ''),
         defaultHostName = hasLocation && location.hostname,
         defaultPort = hasLocation && (location.port || undefined),
-        buildMap = [],
+        buildMap = {},
         masterConfig = (module.config && module.config()) || {};
 
     text = {


### PR DESCRIPTION
The buildMap variable was being used like an object (indexed with strings) which arrays of course can support like any object but I thought it would make it clearer to initialize it with an object literal rather than array literal since array methods aren't being used for the variable.
