### PR TITLE
Support text in node-webkit.

### DIFF
--- a/text.js
+++ b/text.js
@@ -238,9 +238,7 @@ define(['module'], function (module) {
             typeof process !== "undefined" &&
             process.versions &&
             !!process.versions.node &&
-            //Make sure it's not node-webkit and regular require
-            !(!!process.versions['node-webkit'] &&
-                require.nodeRequire === undefined))) {
+            !process.versions['node-webkit'])) {
         //Using special require.nodeRequire, something added by r.js.
         fs = require.nodeRequire('fs');
 


### PR DESCRIPTION
Node-webkit allows loading with require in node's context, so just just
skip the node support if it is node-webkit.
