### PR TITLE
Fixes issue where the text plugin does not honour 'empty:' config baths ...

### DIFF
--- a/text.js
+++ b/text.js
@@ -176,6 +176,12 @@ define(['module'], function (module) {
                 useXhr = (masterConfig.useXhr) ||
                          text.useXhr;
 
+            // Do not load if it is an empty: url
+            if (url.indexOf('empty:') === 0) {
+                onLoad();
+                return;
+            }
+
             //Load the text. Use XHR if possible and in a browser.
             if (!hasLocation || useXhr(url, defaultProtocol, defaultHostName, defaultPort)) {
                 text.get(url, function (content) {


### PR DESCRIPTION
...when building using r.js

References the r.js issue #493 (https://github.com/jrburke/r.js/issues/493). User who reported that issue has not created the issue on the text repository.
