### PR TITLE
Added very useful openXhr hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ requirejs.config({
                 //object from this function.
                 //Available in text.js 2.0.1 or later.
             },
+            openXhr: function (xhr, url) {
+                //Called when XHR is already created but not opended
+                //call xhr.open('GET', url, true)
+                //Useful for various things:
+                //translations (adding 'en' prefix to url)
+                //cross-domain (IE can't handle cross-domain resource
+                //              and need to be proxied)
+                //xhr: the xhr object
+                //url: the url that is going to be fetched.
+            },
             onXhrComplete: function (xhr, url) {
                 //Called whenever an XHR has completed its work. Useful
                 //if browser-specific xhr cleanup needs to be done.

--- a/text.js
+++ b/text.js
@@ -75,6 +75,22 @@ define(['module'], function (module) {
         },
 
         /**
+         * Opens Xhr.
+         * You can change url or method.
+         * It's useful for translated resources or when dealing with 
+         * cross-domain-requests for IE versions < 10
+         * which don't support proper headers.
+         * http://en.wikipedia.org/wiki/Cross-origin_resource_sharing
+         * Normaly it's just:
+         * xhr.open('GET', url, true);
+         * @param {Object} xhr object
+         * @param {String} url to fetch
+         */
+        openXhr: masterConfig.openXhr || function(xhr, url){
+            xhr.open('GET', url, true);
+        },
+
+        /**
          * Parses a resource name into its component parts. Resource names
          * look like: module/name.ext!strip, where the !strip part is
          * optional.
@@ -264,7 +280,7 @@ define(['module'], function (module) {
             text.createXhr())) {
         text.get = function (url, callback, errback, headers) {
             var xhr = text.createXhr(), header;
-            xhr.open('GET', url, true);
+            text.openXhr(xhr, url);
 
             //Allow plugins direct access to xhr headers
             if (headers) {


### PR DESCRIPTION
This commit ads openXhr hook which allow to change fetched url or fetched method. It's backward compatible. It's usefull when you need for some reason change an url, for example cross-domain-request proxy, resource translations or  whatever ;) It's just usefull.
