### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,10 @@
     "bugs": {
         "web": "https://github.com/requirejs/text/issues"
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/requirejs/text.git"
-        }
-    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/requirejs/text.git"
+    },
     "licenses": [
         {
             "type": "MIT",


### PR DESCRIPTION
Using this module as a dependency in a package.json file:

```
{
  "name": "test",
  "version": "0.0.1",
  "dependencies": {
    "text": "requirejs/text#2.0.10"
  }
}
```

Results in this warning:

```
npm WARN package.json text@2.0.10 'repositories' (plural) Not supported. Please pick one as the 'repository' field
```

This commit fixes that, according to the recommendation given by npm. :-)

Thanks for a great plugin!
