### PR TITLE
atom-shell compability

### DIFF
--- a/text.js
+++ b/text.js
@@ -244,7 +244,8 @@ define(['module'], function (module) {
             typeof process !== "undefined" &&
             process.versions &&
             !!process.versions.node &&
-            !process.versions['node-webkit'])) {
+            !process.versions['node-webkit']
+            !process.versions['atom-shell'])) {
         //Using special require.nodeRequire, something added by r.js.
         fs = require.nodeRequire('fs');
 


### PR DESCRIPTION
atom-shell have node env like node-webkit. Maybe this expression (for node-webkit, atom-shell, etc.) can be taken in the config?