### PR TITLE
Loading text files with requires.js fails in IE

### DIFF
--- a/text.js
+++ b/text.js
@@ -55,7 +55,7 @@ define(['module'], function (module) {
         createXhr: masterConfig.createXhr || function () {
             //Would love to dump the ActiveX crap in here. Need IE 6 to die first.
             var xhr, i, progId;
-            if (typeof XMLHttpRequest !== "undefined") {
+            if (!(typeof ActiveXObject !== "undefined" && /file\:/i.test(location.protocol)) && (typeof XMLHttpRequest !== "undefined")) {
                 return new XMLHttpRequest();
             } else if (typeof ActiveXObject !== "undefined") {
                 for (i = 0; i < 3; i += 1) {


### PR DESCRIPTION
'Access is denied`is thrown on IE10 when using the`text plugin`from the`file:// protocol`and hence making calls to another`file:// protocol`

An alternative could be, if the `/file\:/i.test(location.protocol)` to use the `ActiveXObject` which works instead of `XMLHttpRequest`.
