### PR TITLE
Don't scan the whole file for a BOM

### DIFF
--- a/text.js
+++ b/text.js
@@ -252,7 +252,7 @@ define(['module'], function (module) {
             try {
                 var file = fs.readFileSync(url, 'utf8');
                 //Remove BOM (Byte Mark Order) from utf8 files if it is there.
-                if (file.indexOf('\uFEFF') === 0) {
+                if (file[0] === '\uFEFF') {
                     file = file.substring(1);
                 }
                 callback(file);


### PR DESCRIPTION
That's rather pointless if we only want to check the first character anyway
