### PR TITLE
Add config hook to parse module name

### DIFF
--- a/text.js
+++ b/text.js
@@ -109,6 +109,10 @@ define(['module'], function (module) {
                 }
             }
 
+            if (masterConfig.secondaryParseModuleName) {
+                modName = masterConfig.secondaryParseModuleName(modName);
+            }
+
             return {
                 moduleName: modName,
                 ext: ext,


### PR DESCRIPTION
Adding configuration hook that will allow a secondary parsing of the
moduleName.
