### PR TITLE
Provided module name in define()

### DIFF
--- a/text.js
+++ b/text.js
@@ -8,7 +8,7 @@
   define, window, process, Packages,
   java, location, Components, FileUtils */
 
-define(['module'], function (module) {
+define('text', ['module'], function (module) {
     'use strict';
 
     var text, fs, Cc, Ci, xpcIsWindows,


### PR DESCRIPTION
It will make the plugin usable without the need of requirejs optimizer on projects declaring the plugin directly in their html file (not in `requirejs.config()`)
