### PR TITLE
The default port is not computed correctly. Therefore, for an URL wit…

### DIFF
--- a/text.js
+++ b/text.js
@@ -17,7 +17,7 @@ define(['module'], function (module) {
         hasLocation = typeof location !== 'undefined' && location.href,
         defaultProtocol = hasLocation && location.protocol && location.protocol.replace(/\:/, ''),
         defaultHostName = hasLocation && location.hostname,
-        defaultPort = hasLocation && (location.port || undefined),
+        defaultPort = hasLocation && (location.port || (defaultProtocol === 'https' ? '443' : '80')),
         buildMap = {},
         masterConfig = (module.config && module.config()) || {};
 


### PR DESCRIPTION
The default port is not computed correctly. Therefore, for a URL using the default port, the function useXHR always return false.

It reasonable to think that the variable "defaultPort" is always defined.

