### PR TITLE
Remove non-essential files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "license": "MIT",
     "volo": {
         "url": "https://raw.github.com/requirejs/text/{version}/text.js"
-    }
+    },
+    "files": [
+        "text.js"
+    ]
 }


### PR DESCRIPTION
An .npmignore file with the following contents could also be used.
```
.npmignore
bower.json
```