### PR TITLE
Add error handling to CORS text module request

### DIFF
--- a/text.js
+++ b/text.js
@@ -216,6 +216,10 @@ define(['module'], function (module) {
                 req([nonStripName], function (content) {
                     text.finishLoad(parsed.moduleName + '.' + parsed.ext,
                                     parsed.strip, content, onLoad);
+                }, function (err) {
+                    if (onLoad.error) {
+                        onLoad.error(err);
+                    }
                 });
             }
         },


### PR DESCRIPTION
This is a fix for Issue #139. It applies the same error handling as the useXHR branch.

I've tested this fix in our development environment and the behavior is as desired; any error from the module wrapper request is propagated back to the original text load error handler.